### PR TITLE
Completely draw in WASM land

### DIFF
--- a/sandy-worker.js
+++ b/sandy-worker.js
@@ -14,13 +14,13 @@ async function init_wasm() {
 
     self.onmessage = async event => {
         if (event.data.elevationData && event.data.grains) {
-            image = Image.new(event.data.elevationData, event.data.grains, event.data.size, event.data.width, event.data.height, event.data.dampingFactor, event.data.repelRadius);
+            image = Image.new(event.data.elevationData, event.data.grains, event.data.size, event.data.width, event.data.height, event.data.dampingFactor, event.data.repelRadius, event.data.steps, event.data.stepDepth);
             debug = event.data.debug;
         } else if (event.data.action === 'update') {
             const startTime = performance.now();
-            const grains = image.update_grains(event.data.globalVx, event.data.globalVy, event.data.mouseX, event.data.mouseY);
+            const alphaData = image.update_grains(event.data.globalVx, event.data.globalVy, event.data.mouseX, event.data.mouseY);
 
-            self.postMessage({ grains });
+            self.postMessage({ alphaData });
 
             if (debug) {
                 const endTime = performance.now();

--- a/sandy.js
+++ b/sandy.js
@@ -191,6 +191,8 @@ SandyImage.prototype.startWorker = function () {
                 height: this.canvas.height,
                 repelRadius: this.repelRadius,
                 dampingFactor: this.dampingFactor,
+                steps: this.steps,
+                stepDepth: this.stepDepth,
                 debug: this.debug,
             });
 
@@ -201,21 +203,22 @@ SandyImage.prototype.startWorker = function () {
         const startTime = performance.now();
 
         this.updating = false;
-        const updatedGrains = event.data.grains;
 
-        this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        const alphaData = new Uint8ClampedArray(event.data.alphaData.buffer);
 
-        this.ctx.beginPath();
+        // Create a full RGBA array with black color and our alpha values
+        const imageData = this.ctx.createImageData(this.canvas.width, this.canvas.height);
+        const rgba = imageData.data;
 
-        this.ctx.fillStyle = `rgba(0, 0, 0, ${1.0 / this.steps / this.stepDepth})`;
-
-        for (let i = 0; i < updatedGrains.length; i += 2) {
-            const x = updatedGrains[i];
-            const y = updatedGrains[i + 1];
-            this.ctx.fillRect(x, y, this.size, this.size);
+        for (let i = 0; i < alphaData.length; i++) {
+            const rgbaIndex = i * 4;
+            rgba[rgbaIndex] = 0;     // R = 0 (black)
+            rgba[rgbaIndex + 1] = 0; // G = 0 (black)
+            rgba[rgbaIndex + 2] = 0; // B = 0 (black)
+            rgba[rgbaIndex + 3] = alphaData[i]; // Alpha from our buffer
         }
 
-        this.ctx.fill();
+        this.ctx.putImageData(imageData, 0, 0);
 
         if (this.debug) {
             const endTime = performance.now();


### PR DESCRIPTION
This means the JS code does not have to make a `fillRect()` call for each grain. Thus, the drawing do not slow down when the grain count is increased.